### PR TITLE
Only remove session after notifying subscribers

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -176,8 +176,8 @@ class GoTrueClient {
       if (response.error != null) return response;
     }
 
-    _removeSession();
     _notifyAllSubscribers(AuthChangeEvent.signedOut);
+    _removeSession();
 
     return GotrueResponse();
   }


### PR DESCRIPTION
Fixes error on signOut.

Caused by session being set to null and then AuthCallback is called with `currentSession!`. (which signifies currentSession is not null)
Ref: https://github.com/supabase/gotrue-dart/blob/7e58474b444e7d9ea303d11dd058d07f68b3d781/lib/src/gotrue_client.dart#L300

This PR notifies listeners before removing the session.


Another approach would be, to make AuthCallback take a nullable session.