### PR TITLE
fix: URL encode redirectTo

### DIFF
--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -132,7 +132,8 @@ class GoTrueApi {
       urlParams.add('scopes=${options!.scopes!}');
     }
     if (options?.redirectTo != null) {
-      urlParams.add('redirect_to=${options!.redirectTo!}');
+      final encodedRedirectTo = Uri.encodeComponent(options!.redirectTo!);
+      urlParams.add('redirect_to=$encodedRedirectTo');
     }
     return '$url/authorize?${urlParams.join('&')}';
   }


### PR DESCRIPTION
Fixes https://github.com/supabase/gotrue/issues/90

Missed the URL encoding of the http parameter. Thanks @icecream78 for helping out 😁 