### PR TITLE
Rename provider

### DIFF
--- a/lib/gotrue.dart
+++ b/lib/gotrue.dart
@@ -3,7 +3,7 @@ library gotrue;
 export 'src/auth_options.dart';
 export 'src/constants.dart' show AuthChangeEvent;
 export 'src/gotrue_client.dart';
-export 'src/provider.dart';
+export 'src/provider_enum.dart';
 export 'src/session.dart';
 export 'src/user.dart';
 export 'src/user_attributes.dart';

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -164,7 +164,7 @@ class GoTrueApi {
   }
 
   String getUrlForProvider(ProviderEnum provider, AuthOptions? options) {
-    final urlParams = ['provider=${provider.name()}'];
+    final urlParams = ['provider=${provider.name}'];
     if (options?.scopes != null) {
       urlParams.add('scopes=${options!.scopes!}');
     }

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -6,7 +6,7 @@ import 'fetch.dart';
 import 'fetch_options.dart';
 import 'gotrue_error.dart';
 import 'gotrue_response.dart';
-import 'provider.dart';
+import 'provider_enum.dart';
 import 'session.dart';
 import 'user.dart';
 import 'user_attributes.dart';
@@ -163,7 +163,7 @@ class GoTrueApi {
     }
   }
 
-  String getUrlForProvider(Provider provider, AuthOptions? options) {
+  String getUrlForProvider(ProviderEnum provider, AuthOptions? options) {
     final urlParams = ['provider=${provider.name()}'];
     if (options?.scopes != null) {
       urlParams.add('scopes=${options!.scopes!}');

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -274,7 +274,7 @@ class GoTrueClient {
   GotrueSessionResponse _handleProviderSignIn(
       ProviderEnum provider, AuthOptions? options) {
     final url = api.getUrlForProvider(provider, options);
-    return GotrueSessionResponse(provider: provider.name(), url: url);
+    return GotrueSessionResponse(provider: provider.name, url: url);
   }
 
   void _saveSession(Session session) {

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -8,7 +8,7 @@ import 'cookie_options.dart';
 import 'gotrue_api.dart';
 import 'gotrue_error.dart';
 import 'gotrue_response.dart';
-import 'provider.dart';
+import 'provider_enum.dart';
 import 'session.dart';
 import 'subscription.dart';
 import 'user.dart';
@@ -74,7 +74,7 @@ class GoTrueClient {
   Future<GotrueSessionResponse> signIn(
       {String? email,
       String? password,
-      Provider? provider,
+      ProviderEnum? provider,
       AuthOptions? options}) async {
     _removeSession();
 
@@ -272,7 +272,7 @@ class GoTrueClient {
 
   /// return provider url only
   GotrueSessionResponse _handleProviderSignIn(
-      Provider provider, AuthOptions? options) {
+      ProviderEnum provider, AuthOptions? options) {
     final url = api.getUrlForProvider(provider, options);
     return GotrueSessionResponse(provider: provider.name(), url: url);
   }

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -1,7 +1,0 @@
-enum Provider { azure, bitbucket, facebook, github, gitlab, google }
-
-extension ProviderName on Provider {
-  String name() {
-    return toString().split('.').last;
-  }
-}

--- a/lib/src/provider_enum.dart
+++ b/lib/src/provider_enum.dart
@@ -1,7 +1,5 @@
 enum ProviderEnum { azure, bitbucket, facebook, github, gitlab, google }
 
 extension ProviderName on ProviderEnum {
-  String name() {
-    return toString().split('.').last;
-  }
+  String get name => toString().split('.').last;
 }

--- a/lib/src/provider_enum.dart
+++ b/lib/src/provider_enum.dart
@@ -1,0 +1,7 @@
+enum ProviderEnum { azure, bitbucket, facebook, github, gitlab, google }
+
+extension ProviderName on ProviderEnum {
+  String name() {
+    return toString().split('.').last;
+  }
+}

--- a/test/provider_enum_test.dart
+++ b/test/provider_enum_test.dart
@@ -21,7 +21,7 @@ void main() {
   });
 
   test('signIn() with Provider', () async {
-    final res = await client.signIn(provider: Provider.google);
+    final res = await client.signIn(provider: ProviderEnum.google);
     final error = res.error;
     final url = res.url;
     final provider = res.provider;
@@ -32,7 +32,7 @@ void main() {
 
   test('signIn() with Provider and options', () async {
     final res = await client.signIn(
-        provider: Provider.github,
+        provider: ProviderEnum.github,
         options: AuthOptions(
           redirectTo: 'redirectToURL',
           scopes: 'repo',


### PR DESCRIPTION
## What kind of change does this PR introduce?

1. Change Provider to ProviderEnum
2. change extension method "name()" to getter "name"
   you now write provider.name instead of provider.name()

## What is the current behavior?

Closes #19 

## What is the new behavior?
-

## Additional context

This PR solves name conflicts with riverpod.
