### PR TITLE
setAuth() method for setting the session with a provided jwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ doc/api/
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
 .vscode/
+.env

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -1,15 +1,9 @@
 import 'package:gotrue/gotrue.dart';
 
-import 'auth_options.dart';
 import 'cookie_options.dart';
 import 'fetch.dart';
 import 'fetch_options.dart';
 import 'gotrue_error.dart';
-import 'gotrue_response.dart';
-import 'provider.dart';
-import 'session.dart';
-import 'user.dart';
-import 'user_attributes.dart';
 
 class GoTrueApi {
   String url;

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -7,12 +7,7 @@ import 'constants.dart';
 import 'cookie_options.dart';
 import 'gotrue_api.dart';
 import 'gotrue_error.dart';
-import 'gotrue_response.dart';
-import 'provider.dart';
-import 'session.dart';
 import 'subscription.dart';
-import 'user.dart';
-import 'user_attributes.dart';
 import 'uuid.dart';
 
 class GoTrueClient {

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -174,7 +174,7 @@ class GoTrueClient {
   /// Overrides the JWT on the current client. The JWT will then be sent in all subsequent network requests.
   Session setAuth(String accessToken) =>
       currentSession = currentSession?.copyWith(accessToken: accessToken) ??
-          Session(accessToken: accessToken);
+          Session(accessToken: accessToken, tokenType: 'bearer');
 
   /// Gets the session data from a oauth2 callback URL
   Future<GotrueSessionResponse> getSessionFromUrl(

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -171,6 +171,15 @@ class GoTrueClient {
     return response;
   }
 
+  /// Sets the session data from refresh_token and returns current Session and Error
+  Future<GotrueSessionResponse> setSession(String refreshToken) async {
+    if (refreshToken.isEmpty) {
+      final error = GotrueError('No current session.');
+      return GotrueSessionResponse(error: error);
+    }
+    return _callRefreshToken(refreshToken: refreshToken);
+  }
+
   /// Overrides the JWT on the current client. The JWT will then be sent in all subsequent network requests.
   Session setAuth(String accessToken) =>
       currentSession = currentSession?.copyWith(accessToken: accessToken) ??

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -171,6 +171,11 @@ class GoTrueClient {
     return response;
   }
 
+  /// Overrides the JWT on the current client. The JWT will then be sent in all subsequent network requests.
+  Session setAuth(String accessToken) =>
+      currentSession = currentSession?.copyWith(accessToken: accessToken) ??
+          Session(accessToken: accessToken);
+
   /// Gets the session data from a oauth2 callback URL
   Future<GotrueSessionResponse> getSessionFromUrl(
     Uri originUrl, {

--- a/lib/src/session.dart
+++ b/lib/src/session.dart
@@ -54,4 +54,22 @@ class Session {
     final data = {'currentSession': toJson(), 'expiresAt': expiresAt};
     return json.encode(data);
   }
+
+  Session copyWith({
+    String? accessToken,
+    int? expiresIn,
+    String? refreshToken,
+    String? tokenType,
+    String? providerToken,
+    User? user,
+  }) {
+    return Session(
+      accessToken: accessToken ?? this.accessToken,
+      expiresIn: expiresIn ?? this.expiresIn,
+      refreshToken: refreshToken ?? this.refreshToken,
+      tokenType: tokenType ?? this.tokenType,
+      providerToken: providerToken ?? this.providerToken,
+      user: user ?? this.user,
+    );
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
 version: 0.1.1
-homepage: 'https://supabase.io'
-repository: 'https://github.com/supabase/gotrue-dart'
+homepage: "https://supabase.io"
+repository: "https://github.com/supabase/gotrue-dart"
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   http: ^0.13.0
   jwt_decode: ^0.3.1
 
 dev_dependencies:
-  args: ^2.3.0
+  dotenv: ^3.0.0
   lint: ^1.5.1
   test: ^1.16.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,5 +12,6 @@ dependencies:
   jwt_decode: ^0.3.1
 
 dev_dependencies:
+  args: ^2.3.0
   lint: ^1.5.1
   test: ^1.16.4

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,16 +1,61 @@
 import 'dart:convert';
+import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:gotrue/gotrue.dart';
 import 'package:gotrue/src/user_attributes.dart';
 import 'package:jwt_decode/jwt_decode.dart';
 import 'package:test/test.dart';
 
-void main() {
-  const gotrueUrl = 'http://localhost:9999';
-  const annonToken = '';
+void main(List<String> arguments) {
   final timestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
-  final email = 'fake$timestamp@email.com';
-  const password = 'secret';
+
+  final parser = ArgParser();
+
+  parser.addOption(
+    'url',
+    abbr: 'u',
+    defaultsTo: 'http://localhost:9999',
+    help: 'The URL of a GoTrue server instance for testing against.',
+  );
+  parser.addOption(
+    'token',
+    abbr: 't',
+    defaultsTo: '',
+    help: 'Anonymous access token for the GoTrue server.',
+  );
+  parser.addOption(
+    'email',
+    abbr: 'e',
+    defaultsTo: 'fake$timestamp@email.com',
+    help:
+        'Email address to be used to create a new user account on the GoTrue server.\nBy default, a unique address is generated based on the current timestamp.',
+  );
+  parser.addOption(
+    'password',
+    abbr: 'p',
+    defaultsTo: 'secret',
+    help:
+        'Password to be used to create a new user account on the GoTrue server.',
+  );
+  parser.addFlag(
+    'help',
+    abbr: 'h',
+    negatable: false,
+    help: 'Show this help info.',
+  );
+
+  final args = parser.parse(arguments);
+
+  if (args['help'] == true) {
+    print(parser.usage);
+    exit(0);
+  }
+
+  final gotrueUrl = args['url'].toString();
+  final annonToken = args['token'].toString();
+  final email = args['email'].toString();
+  final password = args['password'].toString();
 
   group('client', () {
     late GoTrueClient client;
@@ -46,23 +91,23 @@ void main() {
       );
       final data = response.data;
       final error = response.error;
-      expect(error, isNull);
-      expect(data?.accessToken is String, true);
-      expect(data?.refreshToken is String, true);
-      expect(data?.user?.id is String, true);
+      expect(error?.message, isNull);
+      expect(data?.accessToken, isA<String>());
+      expect(data?.refreshToken, isA<String>());
+      expect(data?.user?.id, isA<String>());
     });
 
     test('signIn()', () async {
       final response = await client.signIn(email: email, password: password);
-      final data = response.data!;
+      final data = response.data;
       final error = response.error;
 
-      expect(error, isNull);
-      expect(data.accessToken is String, true);
-      expect(data.refreshToken is String, true);
-      expect(data.user?.id is String, true);
+      expect(error?.message, isNull);
+      expect(data?.accessToken, isA<String>());
+      expect(data?.refreshToken, isA<String>());
+      expect(data?.user?.id, isA<String>());
 
-      final payload = Jwt.parseJwt(data.accessToken);
+      final payload = Jwt.parseJwt(data!.accessToken);
       final persistSession = json.decode(data.persistSessionString);
       // ignore: avoid_dynamic_calls
       expect(payload['exp'], persistSession['expiresAt']);
@@ -70,7 +115,7 @@ void main() {
 
     test('Get user', () async {
       final user = client.user();
-      expect(user?.id is String, true);
+      expect(user?.id, isA<String>());
       expect(user?.appMetadata['provider'], 'email');
     });
 
@@ -90,20 +135,20 @@ void main() {
           await client.update(UserAttributes(data: {'hello': 'world'}));
       final data = response.data;
       final error = response.error;
-      expect(error, isNull);
-      expect(data?.id is String, true);
+      expect(error?.message, isNull);
+      expect(data?.id, isA<String>());
       expect(data?.userMetadata['hello'], 'world');
     });
 
     test('Get user after updating', () async {
       final user = client.user();
-      expect(user?.id is String, true);
+      expect(user?.id, isA<String>());
       expect(user?.userMetadata['hello'], 'world');
     });
 
     test('signOut', () async {
       final res = await client.signOut();
-      expect(res.error, isNull);
+      expect(res.error?.message, isNull);
     });
 
     test('Get user after logging out', () async {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -130,6 +130,17 @@ void main(List<String> arguments) {
       expect(newClient.currentSession?.accessToken, equals(jwt));
     });
 
+    test('Set session', () async {
+      final refreshToken = client.currentSession?.refreshToken ?? '';
+      expect(refreshToken, isNotEmpty);
+
+      final newClient = GoTrueClient(url: gotrueUrl);
+
+      expect(newClient.currentSession?.accessToken ?? '', isEmpty);
+      newClient.setSession(refreshToken);
+      expect(newClient.currentSession?.accessToken ?? '', isNotEmpty);
+    });
+
     test('Update user', () async {
       final response =
           await client.update(UserAttributes(data: {'hello': 'world'}));

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -92,10 +92,16 @@ void main() {
       final refreshToken = client.currentSession?.refreshToken ?? '';
       expect(refreshToken, isNotEmpty);
 
-      final newClient = GoTrueClient(url: gotrueUrl);
+      final newClient = GoTrueClient(
+        url: gotrueUrl,
+        headers: {
+          'apikey': anonToken,
+        },
+      );
 
+      expect(newClient.currentSession?.refreshToken ?? '', isEmpty);
       expect(newClient.currentSession?.accessToken ?? '', isEmpty);
-      newClient.setSession(refreshToken);
+      await newClient.setSession(refreshToken);
       expect(newClient.currentSession?.accessToken ?? '', isNotEmpty);
     });
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -74,6 +74,17 @@ void main() {
       expect(user?.appMetadata['provider'], 'email');
     });
 
+    test('Set auth', () async {
+      final jwt = client.currentSession?.accessToken ?? '';
+      expect(jwt, isNotEmpty);
+
+      final newClient = GoTrueClient(url: gotrueUrl, autoRefreshToken: false);
+
+      expect(newClient.currentSession?.accessToken, isNot(equals(jwt)));
+      newClient.setAuth(jwt);
+      expect(newClient.currentSession?.accessToken, equals(jwt));
+    });
+
     test('Update user', () async {
       final response =
           await client.update(UserAttributes(data: {'hello': 'world'}));

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
-import 'dart:io';
 
-import 'package:args/args.dart';
+import 'package:dotenv/dotenv.dart' show env;
 import 'package:gotrue/gotrue.dart';
 import 'package:gotrue/src/user_attributes.dart';
 import 'package:jwt_decode/jwt_decode.dart';
@@ -10,52 +9,10 @@ import 'package:test/test.dart';
 void main(List<String> arguments) {
   final timestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
 
-  final parser = ArgParser();
-
-  parser.addOption(
-    'url',
-    abbr: 'u',
-    defaultsTo: 'http://localhost:9999',
-    help: 'The URL of a GoTrue server instance for testing against.',
-  );
-  parser.addOption(
-    'token',
-    abbr: 't',
-    defaultsTo: '',
-    help: 'Anonymous access token for the GoTrue server.',
-  );
-  parser.addOption(
-    'email',
-    abbr: 'e',
-    defaultsTo: 'fake$timestamp@email.com',
-    help:
-        'Email address to be used to create a new user account on the GoTrue server.\nBy default, a unique address is generated based on the current timestamp.',
-  );
-  parser.addOption(
-    'password',
-    abbr: 'p',
-    defaultsTo: 'secret',
-    help:
-        'Password to be used to create a new user account on the GoTrue server.',
-  );
-  parser.addFlag(
-    'help',
-    abbr: 'h',
-    negatable: false,
-    help: 'Show this help info.',
-  );
-
-  final args = parser.parse(arguments);
-
-  if (args['help'] == true) {
-    print(parser.usage);
-    exit(0);
-  }
-
-  final gotrueUrl = args['url'].toString();
-  final annonToken = args['token'].toString();
-  final email = args['email'].toString();
-  final password = args['password'].toString();
+  final gotrueUrl = env['GOTRUE_URL'] ?? 'http://localhost:9999';
+  final annonToken = env['GOTRUE_TOKEN'] ?? '';
+  final email = env['GOTRUE_USER_EMAIL'] ?? 'fake$timestamp@email.com';
+  final password = env['GOTRUE_USER_PASS'] ?? 'secret';
 
   group('client', () {
     late GoTrueClient client;

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:dotenv/dotenv.dart' show env;
+import 'package:dotenv/dotenv.dart' show env, load;
 import 'package:gotrue/gotrue.dart';
 import 'package:jwt_decode/jwt_decode.dart';
 import 'package:test/test.dart';
@@ -8,8 +8,10 @@ import 'package:test/test.dart';
 void main() {
   final timestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
 
+  load(); // Load env variables from .env file
+
   final gotrueUrl = env['GOTRUE_URL'] ?? 'http://localhost:9999';
-  final annonToken = env['GOTRUE_TOKEN'] ?? '';
+  final anonToken = env['GOTRUE_TOKEN'] ?? '';
   final email = env['GOTRUE_USER_EMAIL'] ?? 'fake$timestamp@email.com';
   final password = env['GOTRUE_USER_PASS'] ?? 'secret';
 
@@ -20,8 +22,8 @@ void main() {
       client = GoTrueClient(
         url: gotrueUrl,
         headers: {
-          'Authorization': 'Bearer $annonToken',
-          'apikey': annonToken,
+          'Authorization': 'Bearer $anonToken',
+          'apikey': anonToken,
         },
       );
     });
@@ -140,8 +142,8 @@ void main() {
       final client = GoTrueClient(
         url: gotrueUrl,
         headers: {
-          'Authorization': 'Bearer $annonToken',
-          'apikey': annonToken,
+          'Authorization': 'Bearer $anonToken',
+          'apikey': anonToken,
         },
       );
 
@@ -155,8 +157,8 @@ void main() {
       final client = GoTrueClient(
         url: gotrueUrl,
         headers: {
-          'Authorization': 'Bearer $annonToken',
-          'apikey': annonToken,
+          'Authorization': 'Bearer $anonToken',
+          'apikey': anonToken,
           'X-Client-Info': 'supabase-dart/0.0.0'
         },
       );

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -6,7 +6,7 @@ import 'package:gotrue/src/user_attributes.dart';
 import 'package:jwt_decode/jwt_decode.dart';
 import 'package:test/test.dart';
 
-void main(List<String> arguments) {
+void main() {
   final timestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
 
   final gotrueUrl = env['GOTRUE_URL'] ?? 'http://localhost:9999';

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dotenv/dotenv.dart' show env;
 import 'package:gotrue/gotrue.dart';
-import 'package:gotrue/src/user_attributes.dart';
 import 'package:jwt_decode/jwt_decode.dart';
 import 'package:test/test.dart';
 

--- a/test/subscriptions_test.dart
+++ b/test/subscriptions_test.dart
@@ -1,5 +1,4 @@
 import 'package:gotrue/gotrue.dart';
-import 'package:gotrue/src/gotrue_response.dart';
 import 'package:gotrue/src/subscription.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #34 

## What is the current behavior?

There is currently no way to set the current session from a jwt. (For instance, passed to a backend function)

## What is the new behavior?

A setAuth() method has been introduced which mirrors the one from the js client. Intoduced in [this PR](https://github.com/supabase/gotrue-js/pull/83).

