### PR TITLE
fix: export missing types

### DIFF
--- a/lib/gotrue.dart
+++ b/lib/gotrue.dart
@@ -2,7 +2,9 @@ library gotrue;
 
 export 'src/auth_options.dart';
 export 'src/constants.dart' show AuthChangeEvent;
+export 'src/cookie_options.dart';
 export 'src/gotrue_client.dart';
+export 'src/gotrue_error.dart';
 export 'src/gotrue_response.dart';
 export 'src/provider.dart';
 export 'src/session.dart';

--- a/lib/gotrue.dart
+++ b/lib/gotrue.dart
@@ -3,6 +3,7 @@ library gotrue;
 export 'src/auth_options.dart';
 export 'src/constants.dart' show AuthChangeEvent;
 export 'src/cookie_options.dart';
+export 'src/gotrue_api.dart';
 export 'src/gotrue_client.dart';
 export 'src/gotrue_error.dart';
 export 'src/gotrue_response.dart';

--- a/lib/src/gotrue_api.dart
+++ b/lib/src/gotrue_api.dart
@@ -1,9 +1,7 @@
 import 'package:gotrue/gotrue.dart';
 
-import 'cookie_options.dart';
 import 'fetch.dart';
 import 'fetch_options.dart';
-import 'gotrue_error.dart';
 
 class GoTrueApi {
   String url;

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'package:gotrue/gotrue.dart';
 
 import 'constants.dart';
-import 'gotrue_api.dart';
 import 'subscription.dart';
 import 'uuid.dart';
 

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -4,9 +4,7 @@ import 'dart:convert';
 import 'package:gotrue/gotrue.dart';
 
 import 'constants.dart';
-import 'cookie_options.dart';
 import 'gotrue_api.dart';
-import 'gotrue_error.dart';
 import 'subscription.dart';
 import 'uuid.dart';
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

You cannot define `GotrueError` or `GoTrueClient` as type, because it's not exported. In addition, it was not possible to specify custom [CookieOptions](https://github.com/supabase/gotrue-dart/blob/main/lib/src/gotrue_client.dart#L33) because the class wasn't exported too.

## What is the new behavior?
Files are now properly exported.

## Additional context
In addition, I removed unnecessary imports. 

I noticed some types begin with `GoTrue` and some with `Gotrue`. Wouldn't it be better if the beginning would be equal?
Examples:
- `GoTrueClient`
- `GoTrueApi`
vs
- `GotrueError`
- `GotrueResponse`
- `GotrueSession`
