### PR TITLE
Add `slack`, `spotify` and `twitch` Auth providers

### DIFF
--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -7,6 +7,7 @@ enum Provider {
   github,
   gitlab,
   google,
+  twitch,
   twitter,
   slack,
   spotify

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -7,7 +7,9 @@ enum Provider {
   github,
   gitlab,
   google,
-  twitter
+  twitter,
+  slack,
+  spotify
 }
 
 extension ProviderName on Provider {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add new auth providers, following the [October Beta 2021](https://github.com/supabase/supabase/releases/tag/0.21.10) announcement:

> [...] new Auth providers this month: Slack, Spotify 

Furthermore, add `twitch` provider. 
There is a feeling that they just forgot to add it last time in the Supabase client on Dart 🤔

## What is the current behavior?

No issue. While developing my Flutter application, I found that there is no provider data in the `Provider` enum 😉 

## What is the new behavior?

No.

## Additional context

No.
