### PR TITLE
feat: more admin methods

### DIFF
--- a/lib/src/gotrue_admin_api.dart
+++ b/lib/src/gotrue_admin_api.dart
@@ -29,6 +29,10 @@ class GoTrueAdminApi {
     );
   }
 
+  /// Creates a new user.
+  ///
+  /// This function should only be called on a server. Never expose your `service_role` key on the client.
+  ///
   // Requires either an email or phone
   Future<UserResponse> createUser(AdminUserAttributes attributes) async {
     final options = GotrueRequestOptions(
@@ -43,6 +47,11 @@ class GoTrueAdminApi {
     return UserResponse.fromJson(response);
   }
 
+  /// Delete a user. Requires a `service_role` key.
+  ///
+  ///  [id] is the user id of the user you want to remove.
+  ///
+  /// This function should only be called on a server. Never expose your `service_role` key on the client.
   Future<void> deleteUser(String id) async {
     final options = GotrueRequestOptions(headers: _headers);
     await _fetch.request(
@@ -52,16 +61,17 @@ class GoTrueAdminApi {
     );
   }
 
-  Future<List<UserResponse>> listUsers() async {
+  /// Get a list of users.
+  ///
+  /// This function should only be called on a server. Never expose your `service_role` key on the client.
+  Future<List<User>> listUsers() async {
     final options = GotrueRequestOptions(headers: _headers);
     final response = await _fetch.request(
       '$_url/admin/users',
       RequestMethodType.get,
       options: options,
     );
-    return (response["users"] as List)
-        .map((e) => UserResponse.fromJson(e))
-        .toList();
+    return (response["users"] as List).map((e) => User.fromJson(e)!).toList();
   }
 
   /// Sends an invite link to an email address.

--- a/lib/src/gotrue_admin_api.dart
+++ b/lib/src/gotrue_admin_api.dart
@@ -29,6 +29,41 @@ class GoTrueAdminApi {
     );
   }
 
+  // Requires either an email or phone
+  Future<UserResponse> createUser(AdminUserAttributes attributes) async {
+    final options = GotrueRequestOptions(
+      headers: _headers,
+      body: attributes.toJson(),
+    );
+    final response = await _fetch.request(
+      '$_url/admin/users',
+      RequestMethodType.post,
+      options: options,
+    );
+    return UserResponse.fromJson(response);
+  }
+
+  Future<void> deleteUser(String id) async {
+    final options = GotrueRequestOptions(headers: _headers);
+    await _fetch.request(
+      '$_url/admin/users/$id',
+      RequestMethodType.delete,
+      options: options,
+    );
+  }
+
+  Future<List<UserResponse>> listUsers() async {
+    final options = GotrueRequestOptions(headers: _headers);
+    final response = await _fetch.request(
+      '$_url/admin/users',
+      RequestMethodType.get,
+      options: options,
+    );
+    return (response["users"] as List)
+        .map((e) => UserResponse.fromJson(e))
+        .toList();
+  }
+
   /// Sends an invite link to an email address.
   Future<UserResponse> inviteUserByEmail(
     String email, {
@@ -36,15 +71,10 @@ class GoTrueAdminApi {
     Map<String, dynamic>? data,
   }) async {
     final body = {'email': email};
-    final urlParams = <String, String>{};
-    if (redirectTo != null) {
-      final encodedRedirectTo = Uri.encodeComponent(redirectTo);
-      urlParams['redirect_to'] = encodedRedirectTo;
-    }
     final fetchOptions = GotrueRequestOptions(
       headers: _headers,
       body: body,
-      query: urlParams,
+      redirectTo: redirectTo,
     );
 
     final response = await _fetch.request(

--- a/lib/src/types/user_attributes.dart
+++ b/lib/src/types/user_attributes.dart
@@ -39,7 +39,7 @@ class AdminUserAttributes extends UserAttributes {
   ///
   /// Note: When using the GoTrueAdminApi and wanting to modify a user's metadata,
   /// this attribute is used instead of UserAttributes data.
-  final Object? userMetadata;
+  final Map<String, dynamic>? userMetadata;
 
   /// A custom data object to store the user's application specific metadata. This maps to the `auth.users.app_metadata` column.
   ///
@@ -47,7 +47,7 @@ class AdminUserAttributes extends UserAttributes {
   ///
   /// The `app_metadata` should be a JSON object that includes app-specific info, such as identity providers, roles, and other
   /// access control information.
-  final Object? appMetadata;
+  final Map<String, dynamic>? appMetadata;
 
   /// Confirms the user's email address if set to true.
   ///
@@ -79,12 +79,7 @@ class AdminUserAttributes extends UserAttributes {
     this.emailConfirm,
     this.phoneConfirm,
     this.banDuration,
-  })  : assert(userMetadata == null ||
-            userMetadata is List ||
-            userMetadata is Map),
-        assert(
-            appMetadata == null || appMetadata is List || appMetadata is Map),
-        super(email: email, phone: phone, password: password, data: data);
+  }) : super(email: email, phone: phone, password: password, data: data);
 
   @override
   Map<String, dynamic> toJson() {

--- a/test/admin_test.dart
+++ b/test/admin_test.dart
@@ -99,5 +99,28 @@ void main() {
       expect(res.user?.email, newEmail);
       expect(res.user?.invitedAt, isNotNull);
     });
+
+    test('createUser() creates a new user', () async {
+      final newEmail = 'new${Random.secure().nextInt(4096)}@fake.org';
+      final userMetadata = {"name": "supabase"};
+      final res = await client.admin.createUser(
+          AdminUserAttributes(email: newEmail, userMetadata: userMetadata));
+      expect(res.user, isNotNull);
+      expect(res.user?.email, newEmail);
+      expect(res.user?.userMetadata, userMetadata);
+    });
+  });
+
+  group("User deletion", () {
+    test("deleteUser() deletes an user", () async {
+      final newUser = await client.admin.createUser(AdminUserAttributes(
+        email: 'new${Random.secure().nextInt(4096)}@fake.org',
+        password: password,
+      ));
+      final userLengthBefore = (await client.admin.listUsers()).length;
+      await client.admin.deleteUser(newUser.user!.id);
+      final userLengthAfter = (await client.admin.listUsers()).length;
+      expect(userLengthBefore - 1, userLengthAfter);
+    });
   });
 }


### PR DESCRIPTION
The js function `deleteUser` returns an `UserResponse` object, but for me the api always returned an empty object. I don't know where the issue lies, so I created an issue on gotrue https://github.com/supabase/gotrue/issues/804

In addition, I changed the type of `userMetadata` and `appMetadata` to `Map`. because `List` didn't work.