### PR TITLE
fix: allow nullable role in User.fromJson()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.2.0]
+## [1.2.1]
 
 - fix: allow nullable `role` and `updatedAt` in `User.fromJson()` [#108](https://github.com/supabase/gotrue-dart/pull/108)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [1.2.0]
 
+- fix: allow nullable `role` and `updatedAt` in `User.fromJson()` [#108](https://github.com/supabase/gotrue-dart/pull/108)
+
+## [1.2.0]
+
 - feat: add `createUser()`, `deleteUser()`, and `listUsers()` to admin methods. [#106](https://github.com/supabase/gotrue-dart/pull/106)
 
 ## [1.1.1]

--- a/lib/src/types/user.dart
+++ b/lib/src/types/user.dart
@@ -69,8 +69,8 @@ class User {
       emailConfirmedAt: json['email_confirmed_at'] as String?,
       phoneConfirmedAt: json['phone_confirmed_at'] as String?,
       lastSignInAt: json['last_sign_in_at'] as String?,
-      role: json['role'] as String,
-      updatedAt: json['updated_at'] as String,
+      role: json['role'] as String?,
+      updatedAt: json['updated_at'] as String?,
       identities:
           (json['identities'] as List?)?.cast<Map<String, dynamic>>().map((e) {
         return UserIdentity.fromMap(e);

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.2.0';
+const version = '1.2.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.2.0
+version: 1.2.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 


### PR DESCRIPTION
In response to today's issues (https://status.supabase.com/incidents/zmw9wwlwnj8g), it might be a good idea to not require `role` to be non-nullable if the actual type is nullable.