### PR TITLE
fix: add collection to pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
+  collection: ^1.17.0
   http: ^0.13.0
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4


### PR DESCRIPTION
## What kind of change does this PR introduce?

There was a warning when trying to release a new version, because `collection` package used in `gotrue_client.dart` is not listed on pubspec.yaml. This PR fixes it.

collection v1.17.0 used 2.12.0 as minimal Dart SDK version.