### PR TITLE
chore: downgrade collection and publish v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.1]
+
+- fix: downgrade minimum `collection` version to support wider range of Flutter SDK versions
+
 ## [1.4.0]
 
 - feat: add support for [MFA](https://supabase.com/docs/guides/auth/auth-mfa)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.4.0';
+const version = '1.4.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.4.0
+version: 1.4.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  collection: ^1.17.0
+  collection: ^1.15.0
   http: ^0.13.0
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4


### PR DESCRIPTION
## What kind of change does this PR introduce?

I am just finding out about this, but apparently, the [Flutter SDK specifies the version of collection](https://github.com/flutter/flutter/blob/master/packages/flutter/pubspec.yaml#L11) without giving it any range. Because of this, the latest version of gotrue-dart does not run on certain Flutter versions (not even on the latest stable release). This PR downgrades the minimum version of `collection` to the [oldest version that supports null safety](https://pub.dev/packages/collection/changelog#1150).