### PR TITLE
fix: Use BehaviorSubject for _onAuthStateChangedController

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -10,6 +10,7 @@ import 'package:gotrue/src/types/auth_response.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
 import 'package:jwt_decode/jwt_decode.dart';
+import 'package:rxdart/subjects.dart';
 import 'package:universal_io/io.dart';
 
 import 'types/mfa.dart';
@@ -41,8 +42,19 @@ class GoTrueClient {
 
   int _refreshTokenRetryCount = 0;
 
-  final _onAuthStateChangeController = StreamController<AuthState>.broadcast();
-  // Receive a notification every time an auth event happens.
+  final _onAuthStateChangeController = BehaviorSubject<AuthState>();
+
+  /// Receive a notification every time an auth event happens.
+  ///
+  /// ```dart
+  /// supabase.auth.onAuthStateChange.listen((data) {
+  ///   final AuthChangeEvent event = data.event;
+  ///   final Session? session = data.session;
+  ///   if(event == AuthChangeEvent.signedIn) {
+  ///     // handle signIn event
+  ///   }
+  /// });
+  /// ```
   Stream<AuthState> get onAuthStateChange =>
       _onAuthStateChangeController.stream;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   http: ^0.13.0
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4
+  rxdart: ^0.27.7
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, there are no ways to listen to the very first [recovery event ](https://github.com/supabase/supabase-flutter/blob/main/lib/src/supabase_auth.dart#L89) through `onAuthStateChanged` stream, because `Supabase.initialize()` completes after after the recovery event is handled. 

This PR changes the `_onAuthStateChangedController` to [BehaviorSubject](https://pub.dev/documentation/rxdart/latest/rx/BehaviorSubject-class.html) so that the last event is preserved and can be listened to even after the `Supabase.initialize()` is completed. 

Related https://github.com/supabase/supabase-flutter/issues/331

## Other context

The commit message got mixed up with my previous task, so please ignore it 😂
