### PR TITLE
feat: add providerRefreshToken to session

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -391,6 +391,7 @@ class GoTrueClient {
     final refreshToken = url.queryParameters['refresh_token'];
     final tokenType = url.queryParameters['token_type'];
     final providerToken = url.queryParameters['provider_token'];
+    final providerRefreshToken = url.queryParameters['provider_refresh_token'];
 
     if (accessToken == null) {
       throw _notifyException(AuthException('No access_token detected.'));
@@ -417,6 +418,7 @@ class GoTrueClient {
 
     final session = Session(
       providerToken: providerToken,
+      providerRefreshToken: providerRefreshToken,
       accessToken: accessToken,
       expiresIn: int.parse(expiresIn),
       refreshToken: refreshToken,

--- a/lib/src/types/session.dart
+++ b/lib/src/types/session.dart
@@ -5,6 +5,7 @@ import 'package:jwt_decode/jwt_decode.dart';
 
 class Session {
   final String? providerToken;
+  final String? providerRefreshToken;
   final String accessToken;
 
   /// The number of seconds until the token expires (since it was issued).
@@ -21,6 +22,7 @@ class Session {
     this.refreshToken,
     required this.tokenType,
     this.providerToken,
+    this.providerRefreshToken,
     required this.user,
   });
 
@@ -36,6 +38,7 @@ class Session {
       refreshToken: json['refresh_token'] as String?,
       tokenType: json['token_type'] as String,
       providerToken: json['provider_token'] as String?,
+      providerRefreshToken: json['provider_refresh_token'] as String?,
       user: User.fromJson(json['user'] as Map<String, dynamic>)!,
     );
   }
@@ -47,6 +50,7 @@ class Session {
       'refresh_token': refreshToken,
       'token_type': tokenType,
       'provider_token': providerToken,
+      'provider_refresh_token': providerRefreshToken,
       'user': user.toJson(),
     };
   }
@@ -73,6 +77,7 @@ class Session {
     String? refreshToken,
     String? tokenType,
     String? providerToken,
+    String? providerRefreshToken,
     User? user,
   }) {
     return Session(
@@ -81,6 +86,7 @@ class Session {
       refreshToken: refreshToken ?? this.refreshToken,
       tokenType: tokenType ?? this.tokenType,
       providerToken: providerToken ?? this.providerToken,
+      providerRefreshToken: providerRefreshToken ?? this.providerRefreshToken,
       user: user ?? this.user,
     );
   }

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:dotenv/dotenv.dart' show env, load;
 import 'package:gotrue/gotrue.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
@@ -5,8 +6,10 @@ import 'package:test/test.dart';
 import 'utils.dart';
 
 void main() {
-  const gotrueUrl = 'http://localhost:9998';
-  const annonToken = 'anonKey';
+  load(); // Load env variables from .env file
+
+  final gotrueUrl = env['GOTRUE_URL'] ?? 'http://localhost:9998';
+  final anonToken = env['GOTRUE_TOKEN'] ?? 'anonKey';
 
   late GoTrueClient client;
   late Session session;
@@ -15,8 +18,8 @@ void main() {
     client = GoTrueClient(
       url: gotrueUrl,
       headers: {
-        'Authorization': 'Bearer $annonToken',
-        'apikey': annonToken,
+        'Authorization': 'Bearer $anonToken',
+        'apikey': anonToken,
       },
     );
   });
@@ -62,15 +65,17 @@ void main() {
       const refreshToken = 'my_refresh_token';
       const tokenType = 'my_token_type';
       const providerToken = 'my_provider_token_with_fragment';
+      const providerRefreshToken = 'my_provider_refresh_token';
 
       final url =
-          'http://my-callback-url.com/welcome#access_token=$accessToken&expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken';
+          'http://my-callback-url.com/welcome#access_token=$accessToken&expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken&provider_refresh_token=$providerRefreshToken';
       final res = await client.getSessionFromUrl(Uri.parse(url));
       expect(res.session.accessToken, accessToken);
       expect(res.session.expiresIn, expiresIn);
       expect(res.session.refreshToken, refreshToken);
       expect(res.session.tokenType, tokenType);
       expect(res.session.providerToken, providerToken);
+      expect(res.session.providerRefreshToken, providerRefreshToken);
     });
 
     test('parse provider callback url with fragment and query', () async {
@@ -79,14 +84,17 @@ void main() {
       const refreshToken = 'my_refresh_token';
       const tokenType = 'my_token_type';
       const providerToken = 'my_provider_token_fragment_and_query';
+      const providerRefreshToken = 'my_provider_refresh_token';
+
       final url =
-          'http://my-callback-url.com?page=welcome&foo=bar#access_token=$accessToken&expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken';
+          'http://my-callback-url.com?page=welcome&foo=bar#access_token=$accessToken&expires_in=$expiresIn&refresh_token=$refreshToken&token_type=$tokenType&provider_token=$providerToken&provider_refresh_token=$providerRefreshToken';
       final res = await client.getSessionFromUrl(Uri.parse(url));
       expect(res.session.accessToken, accessToken);
       expect(res.session.expiresIn, expiresIn);
       expect(res.session.refreshToken, refreshToken);
       expect(res.session.tokenType, tokenType);
       expect(res.session.providerToken, providerToken);
+      expect(res.session.providerRefreshToken, providerRefreshToken);
     });
 
     test('parse provider callback url with missing param error', () async {


### PR DESCRIPTION
In response to a recent issue supabase/supabase-flutter#342 I opened,  `session` does not contain `provider_refresh_token` despite the `authResponse` having one. 

Now, the session should contain `provider_refresh_token` (if there is).

Also, the reason `provider_token` turns `null` after Supabase refreshes token does not depend on the parsing issue, but rather that the `authResponse` no longer contains both `provider_token` and `provider_refresh_token`. Therefore, I was not able to set automatic refresh token for provider as well.
