### PR TITLE
Add experimental signInWithIdToken for Apple, Google

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## [1.4.3]
+## [1.5.0]
 
 - feat: add support for `signInWithIdToken`.
+
 ## [1.4.2]
 
 - fix: `onAuthStateChanged` now emits the latest `AuthState` [#116](https://github.com/supabase/gotrue-dart/pull/116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## [1.4.3]
 
 - feat: add support for `signInWithIdToken`.
-- 
 ## [1.4.2]
 
 - fix: `onAuthStateChanged` now emits the latest `AuthState` [#116](https://github.com/supabase/gotrue-dart/pull/116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.3]
+
+- feat: add support for `signInWithIdToken`.
+- 
 ## [1.4.2]
 
 - fix: `onAuthStateChanged` now emits the latest `AuthState` [#116](https://github.com/supabase/gotrue-dart/pull/116)

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -228,9 +228,9 @@ class GoTrueClient {
   }) async {
     _removeSession();
 
-    if (provider != Provider.google || provider != Provider.apple) {
+    if (provider != Provider.google && provider != Provider.apple) {
       throw AuthException('Provider must either be '
-          '${Provider.google.name} or${Provider.apple.name}.');
+          '${Provider.google.name} or ${Provider.apple.name}.');
     }
 
     final response = await _fetch.request(

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -234,7 +234,7 @@ class GoTrueClient {
     }
 
     final response = await _fetch.request(
-      '$_url/token?grant_type=id_token',
+      '$_url/token',
       RequestMethodType.post,
       options: GotrueRequestOptions(
         headers: _headers,
@@ -244,6 +244,7 @@ class GoTrueClient {
           'nonce': nonce,
           'gotrue_meta_security': {'captcha_token': captchaToken},
         },
+        query: {'grant_type': 'id_token'},
       ),
     );
 

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html_common';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -11,6 +10,7 @@ import 'package:gotrue/src/types/auth_response.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
 import 'package:jwt_decode/jwt_decode.dart';
+import 'package:meta/meta.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:universal_io/io.dart';
 
@@ -219,7 +219,9 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
-  @Experimental()
+  ///
+  /// This method is experimental.
+  @experimental
   Future<AuthResponse> signInWithIdToken({
     required Provider provider,
     required String idToken,

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -10,7 +10,6 @@ import 'package:gotrue/src/types/auth_response.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
 import 'package:jwt_decode/jwt_decode.dart';
-import 'package:meta/meta.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:universal_io/io.dart';
 
@@ -219,9 +218,9 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
+  /// This method of signing in only supports [Provider.google] or [Provider.apple].
   ///
   /// This method is experimental.
-  @experimental
   Future<AuthResponse> signInWithIdToken({
     required Provider provider,
     required String idToken,

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:html_common';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -218,8 +219,7 @@ class GoTrueClient {
 
   /// Allows signing in with an ID token issued by certain supported providers.
   /// The [idToken] is verified for validity and a new session is established.
-  ///
-  /// This method is experimental.
+  @Experimental()
   Future<AuthResponse> signInWithIdToken({
     required Provider provider,
     required String idToken,

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -10,6 +10,7 @@ import 'package:gotrue/src/types/auth_response.dart';
 import 'package:gotrue/src/types/fetch_options.dart';
 import 'package:http/http.dart';
 import 'package:jwt_decode/jwt_decode.dart';
+import 'package:meta/meta.dart';
 import 'package:rxdart/subjects.dart';
 import 'package:universal_io/io.dart';
 
@@ -221,6 +222,7 @@ class GoTrueClient {
   /// This method of signing in only supports [Provider.google] or [Provider.apple].
   ///
   /// This method is experimental.
+  @experimental
   Future<AuthResponse> signInWithIdToken({
     required Provider provider,
     required String idToken,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.4.2';
+const version = '1.5.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4
   rxdart: ^0.27.7
+  meta: ^1.9.0
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.4.3
+version: 1.5.0
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.4.2
+version: 1.4.3
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4
   rxdart: ^0.27.7
-  meta: ^1.9.0
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1


### PR DESCRIPTION
Recreates  https://github.com/supabase/gotrue-js/pull/603

This is the endpoint we need to hit for native auth. i'm also going to be working on native auth in the supabase-flutter repo.

Here's a WIP of the PR

https://github.com/supabase/supabase-flutter/blob/signInWithIdToken/README.md#native-auth-example
