### PR TITLE
Fixes incompatible meta version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.1]
+
+- fix: downgrade `meta` to support minimum Flutter version.
+
 ## [1.5.0]
 
 - feat: add support for `signInWithIdToken`.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.5.0';
+const version = '1.5.1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.5.0
+version: 1.5.1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   collection: ^1.15.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   collection: ^1.15.0
@@ -13,7 +13,7 @@ dependencies:
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4
   rxdart: ^0.27.7
-  meta: ^1.9.0
+  meta: ^1.8.0
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1


### PR DESCRIPTION
Fixes issue in `supabase-flutter`.

> 
> Fixes Because every version of flutter from sdk depends on meta 1.8.0 and gotrue >=1.5.0 depends on meta ^1.9.0, flutter from sdk is incompatible with gotrue >=1.5.0.
> And because every version of supabase from git depends on gotrue ^1.5.0, flutter from sdk is incompatible with supabase from git.
> So, because supabase_flutter depends on both flutter from sdk and supabase from git, version solving failed.
> 