### PR TITLE
fix: properly reset refresh retry count

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -599,6 +599,7 @@ class GoTrueClient {
       final refreshDurationBeforeExpires = expiresIn > 60 ? 60 : 1;
       final nextDuration = expiresIn - refreshDurationBeforeExpires;
       if (nextDuration > 0) {
+        _refreshTokenRetryCount = 0;
         final timerDuration = Duration(seconds: nextDuration);
         _setTokenRefreshTimer(timerDuration, refreshCompleter);
       } else {
@@ -670,7 +671,6 @@ class GoTrueClient {
         completer.completeError(error, StackTrace.current);
         throw error;
       }
-      _refreshTokenRetryCount = 0;
 
       _saveSession(authResponse.session!);
       _notifyAllSubscribers(AuthChangeEvent.tokenRefreshed);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -314,7 +314,6 @@ void main() {
       await client.signInWithPassword(password: password, email: email1);
       for (int i = 0; i < 10; i++) {
         final json = client.currentSession!.persistSessionString;
-        print(json);
         await client.recoverSession(json);
       }
     });

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -309,6 +309,15 @@ void main() {
         expect(res.provider, Provider.google);
       });
     });
+
+    test('Repeatedly recover session', () async {
+      await client.signInWithPassword(password: password, email: email1);
+      for (int i = 0; i < 10; i++) {
+        final json = client.currentSession!.persistSessionString;
+        print(json);
+        await client.recoverSession(json);
+      }
+    });
   });
 
   group('Client with custom http client', () {


### PR DESCRIPTION
I'm resetting the count when we successfully set a new session. This should be the case after a call to `_callRefreshToken` with a new session, but for repeatedly calling `_saveSession` from `recoverSession` as well.

close https://github.com/supabase/supabase-flutter/issues/393