### PR TITLE
lower the meta version to v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.4]
+
+- fix: lower the version of `meta` to v1.7.0 to match the requirement for Flutter 2.8.0
+
 ## [1.5.3]
 
 - fix: properly reset refresh retry count [#122](https://github.com/supabase/gotrue-dart/pull/122)

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.5.3';
+const version = '1.5.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.5.3
+version: 1.5.4
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 
@@ -13,7 +13,7 @@ dependencies:
   jwt_decode: ^0.3.1
   universal_io: ^2.0.4
   rxdart: ^0.27.7
-  meta: ^1.8.0
+  meta: ^1.7.0
 
 dev_dependencies:
   dart_jsonwebtoken: ^2.4.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Lowers the version of `meta` to ^1.7.0, because Flutter 2.8.0 requires meta v1.7.0

Fixes https://github.com/supabase/supabase-flutter/issues/404