### PR TITLE
fix: handle invalid refresh token

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -687,6 +687,11 @@ class GoTrueClient {
       );
       return completer.future;
     } catch (error, stack) {
+      if (error is AuthException) {
+        if (error.message == 'Invalid Refresh Token: Refresh Token Not Found') {
+          signOut();
+        }
+      }
       completer.completeError(error, stack);
       return completer.future;
     }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -317,6 +317,19 @@ void main() {
         await client.recoverSession(json);
       }
     });
+
+    test('Sign out on wrong refresh token', () async {
+      await client.signInWithPassword(password: password, email: email1);
+
+      final currentSession = client.currentSession!.toJson()
+        ..['refresh_token'] = 'wrong';
+      final data = {'currentSession': currentSession, 'expiresAt': 100};
+      final session = json.encode(data);
+
+      await client.recoverSession(session);
+
+      expect(client.currentSession, isNull);
+    });
   });
 
   group('Client with custom http client', () {


### PR DESCRIPTION
close supabase/supabase-flutter#412


I'm unsure on how to proceed with the existing error. Should we just handle it silently, or should the error still bubble up?