### PR TITLE
fix: correct expiry margin

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -544,7 +544,7 @@ class GoTrueClient {
     }
 
     final timeNow = (DateTime.now().millisecondsSinceEpoch / 1000).round();
-    if (expiresAt < (timeNow - Constants.expiryMargin.inSeconds)) {
+    if (expiresAt < (timeNow + Constants.expiryMargin.inSeconds)) {
       if (_autoRefreshToken && session.refreshToken != null) {
         final response = await _callRefreshToken(
           refreshCompleter,


### PR DESCRIPTION
I've noticed that the expiry margin gets wrongly applied. If `expiresAt` is minimal more than `timeNow` it still doesn't get fired.

See [gotrue-js](https://github.com/supabase/gotrue-js/blob/master/src/GoTrueClient.ts#L1081) implementation. 