### PR TITLE
fix: use _notifyException to handle recoverSession errors

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -532,15 +532,15 @@ class GoTrueClient {
         persistedData['currentSession'] as Map<String, dynamic>?;
     final expiresAt = persistedData['expiresAt'] as int?;
     if (currentSession == null) {
-      throw AuthException('Missing currentSession.');
+      throw _notifyException(AuthException('Missing currentSession.'));
     }
     if (expiresAt == null) {
-      throw AuthException('Missing expiresAt.');
+      throw _notifyException(AuthException('Missing expiresAt.'));
     }
 
     final session = Session.fromJson(currentSession);
     if (session == null) {
-      throw AuthException('Current session is missing data.');
+      throw _notifyException(AuthException('Current session is missing data.'));
     }
 
     final timeNow = (DateTime.now().millisecondsSinceEpoch / 1000).round();
@@ -553,7 +553,7 @@ class GoTrueClient {
         );
         return response;
       } else {
-        throw AuthException('Session expired.');
+        throw _notifyException(AuthException('Session expired.'));
       }
     } else {
       if (_currentSession == null ||

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -698,8 +698,11 @@ class GoTrueClient {
     _onAuthStateChangeController.add(AuthState(event, currentSession));
   }
 
-  Exception _notifyException(Exception exception) {
-    _onAuthStateChangeController.addError(exception);
+  Exception _notifyException(Exception exception, [StackTrace? stackTrace]) {
+    _onAuthStateChangeController.addError(
+      exception,
+      stackTrace ?? StackTrace.current,
+    );
     return exception;
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, the only way to listen to exceptions thrown during `recoverSession` is to handle `SupabaseAuth.initialSession`, which I think we should move away from, since it's a weird design pattern to just have a variable just for the initial session.

This PR allows users to listen to errors emitted on `recoverSession` by adding `onError()` on `onAuthStateChanged`. So that it is easier to handle the initial auth exceptions as well as on going exceptions happening during token refresh can be all handled through `onAuthStateChanged`.