### PR TITLE
fix: prevent AuthState signedIn with null session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.5.7]
+
+- fix: prevent onAuthStateChange emitting null session when signed in [#133](https://github.com/supabase/gotrue-dart/pull/133)
+
 ## [1.5.6]
 
 - fix: sign out users silently when refresh token is invalid [#126](https://github.com/supabase/gotrue-dart/pull/126)

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -557,9 +557,9 @@ class GoTrueClient {
       }
     } else {
       final shouldEmitEvent = _currentSession == null ||
-          _currentSession?.user.id != session.user.id; 
+          _currentSession?.user.id != session.user.id;
       _saveSession(session);
-      
+
       if (shouldEmitEvent) _notifyAllSubscribers(AuthChangeEvent.signedIn);
 
       return AuthResponse(session: session);

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -558,9 +558,13 @@ class GoTrueClient {
     } else {
       if (_currentSession == null ||
           _currentSession?.user.id != session.user.id) {
+     
+        _saveSession(session);
         _notifyAllSubscribers(AuthChangeEvent.signedIn);
+      } else {
+        _saveSession(session);
       }
-      _saveSession(session);
+
       return AuthResponse(session: session);
     }
   }

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -556,14 +556,12 @@ class GoTrueClient {
         throw _notifyException(AuthException('Session expired.'));
       }
     } else {
-      if (_currentSession == null ||
-          _currentSession?.user.id != session.user.id) {
+      final shouldEmitEvent = _currentSession == null ||
+          _currentSession?.user.id != session.user.id); 
      
-        _saveSession(session);
-        _notifyAllSubscribers(AuthChangeEvent.signedIn);
-      } else {
-        _saveSession(session);
-      }
+      _saveSession(session);
+      
+      if (shouldEmitEvent) _notifyAllSubscribers(AuthChangeEvent.signedIn);
 
       return AuthResponse(session: session);
     }

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -557,7 +557,7 @@ class GoTrueClient {
       }
     } else {
       final shouldEmitEvent = _currentSession == null ||
-          _currentSession?.user.id != session.user.id); 
+          _currentSession?.user.id != session.user.id; 
      
       _saveSession(session);
       

--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -558,7 +558,6 @@ class GoTrueClient {
     } else {
       final shouldEmitEvent = _currentSession == null ||
           _currentSession?.user.id != session.user.id; 
-     
       _saveSession(session);
       
       if (shouldEmitEvent) _notifyAllSubscribers(AuthChangeEvent.signedIn);

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.5.6';
+const version = '1.5.7';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gotrue
 description: A dart client library for the GoTrue API.
-version: 1.5.6
+version: 1.5.7
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/gotrue-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
If  ` _notifyAllSubscribers `is called before` _saveSession`, then the `session` of the emitted `AuthState` will be `null`, because it uses `_currentSession` which is still `null` if `_saveSession` has not been called.


## What is the current behavior?

With #127 the session of the emitted `AuthState` is `null`.

## What is the new behavior?

Same as before #127 , emitted `AuthState` contains the corresponding session.

## Additional context


