### PR TITLE
properly handle completer

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -380,7 +380,7 @@ class GoTrueClient {
       throw AuthException('Not logged in.');
     }
 
-    await _callRefreshToken(refreshCompleter);
+    _callRefreshToken(refreshCompleter);
     return refreshCompleter.future;
   }
 
@@ -414,7 +414,7 @@ class GoTrueClient {
     if (refreshToken.isEmpty) {
       throw AuthException('No current session.');
     }
-    await _callRefreshToken(refreshCompleter, refreshToken: refreshToken);
+    _callRefreshToken(refreshCompleter, refreshToken: refreshToken);
     return refreshCompleter.future;
   }
 
@@ -548,7 +548,7 @@ class GoTrueClient {
     final timeNow = (DateTime.now().millisecondsSinceEpoch / 1000).round();
     if (expiresAt < (timeNow + Constants.expiryMargin.inSeconds)) {
       if (_autoRefreshToken && session.refreshToken != null) {
-        await _callRefreshToken(
+        _callRefreshToken(
           refreshCompleter,
           refreshToken: session.refreshToken,
           accessToken: session.accessToken,
@@ -645,7 +645,7 @@ class GoTrueClient {
   }
 
   /// Generates a new JWT.
-  Future<void> _callRefreshToken(
+  void _callRefreshToken(
     Completer<AuthResponse> completer, {
     String? refreshToken,
     String? accessToken,

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -73,6 +73,7 @@ void main() {
       expect(data?.refreshToken, isA<String>());
       expect(data?.user.id, isA<String>());
       expect(data?.user.userMetadata, {'Hello': 'World'});
+      print(client.currentSession!.persistSessionString);
     });
 
     test('Parsing invalid URL should emit Exception on onAuthStateChange',
@@ -363,6 +364,22 @@ void main() {
         expect(error, isA<AuthException>());
         expect((error as AuthException).statusCode, '420');
       }
+    });
+  });
+
+  group('Client that fails on the first 3 requests', () {
+    late GoTrueClient client;
+
+    setUpAll(() {
+      client = GoTrueClient(
+        url: gotrueUrl,
+        httpClient: RetryTestHttpClient(),
+      );
+    });
+
+    test('Session recovery', () async {
+      await client.recoverSession(
+          '{"currentSession":{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODAzNDE3MDUsInN1YiI6IjRkMjU4M2RhLThkZTQtNDlkMy05Y2QxLTM3YTlhNzRmNTViZCIsImVtYWlsIjoiZmFrZTE2ODAzMzgxMDVAZW1haWwuY29tIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6eyJIZWxsbyI6IldvcmxkIn0sInJvbGUiOiIiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTY4MDMzODEwNX1dLCJzZXNzaW9uX2lkIjoiYzhiOTg2Y2UtZWJkZC00ZGUxLWI4MjAtZjIyOWYyNjg1OGIwIn0.0x1rFlPKbIU1rZPY1SH_FNSZaXerfkFA1Y-EOlhuzUs","expires_in":3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}},"expiresAt":1680341705}');
     });
   });
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -73,7 +73,6 @@ void main() {
       expect(data?.refreshToken, isA<String>());
       expect(data?.user.id, isA<String>());
       expect(data?.user.userMetadata, {'Hello': 'World'});
-      print(client.currentSession!.persistSessionString);
     });
 
     test('Parsing invalid URL should emit Exception on onAuthStateChange',
@@ -369,17 +368,20 @@ void main() {
 
   group('Client that fails on the first 3 requests', () {
     late GoTrueClient client;
+    late RetryTestHttpClient httpClient;
 
     setUpAll(() {
+      httpClient = RetryTestHttpClient();
       client = GoTrueClient(
         url: gotrueUrl,
-        httpClient: RetryTestHttpClient(),
+        httpClient: httpClient,
       );
     });
 
-    test('Session recovery', () async {
+    test('Session recovery succedes after retries', () async {
       await client.recoverSession(
           '{"currentSession":{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODAzNDE3MDUsInN1YiI6IjRkMjU4M2RhLThkZTQtNDlkMy05Y2QxLTM3YTlhNzRmNTViZCIsImVtYWlsIjoiZmFrZTE2ODAzMzgxMDVAZW1haWwuY29tIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6eyJIZWxsbyI6IldvcmxkIn0sInJvbGUiOiIiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTY4MDMzODEwNX1dLCJzZXNzaW9uX2lkIjoiYzhiOTg2Y2UtZWJkZC00ZGUxLWI4MjAtZjIyOWYyNjg1OGIwIn0.0x1rFlPKbIU1rZPY1SH_FNSZaXerfkFA1Y-EOlhuzUs","expires_in":3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}},"expiresAt":1680341705}');
+      expect(httpClient.retryCount, 3);
     });
   });
 }

--- a/test/custom_http_client.dart
+++ b/test/custom_http_client.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart';
+import 'package:universal_io/io.dart';
 
 class CustomHttpClient extends BaseClient {
   @override
@@ -17,6 +18,60 @@ class CustomHttpClient extends BaseClient {
 class NoEmailConfirmationHttpClient extends BaseClient {
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
+    final now = DateTime.now().toIso8601String();
+    return StreamedResponse(
+      Stream.value(
+        utf8.encode(
+          jsonEncode(
+            {
+              'id': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
+              'aud': 'authenticated',
+              'role': 'authenticated',
+              'email': 'fake1@email.com',
+              'phone': '',
+              'confirmation_sent_at': now,
+              'app_metadata': {
+                'provider': 'email',
+                'providers': ['email']
+              },
+              'user_metadata': {},
+              'identities': [
+                {
+                  'id': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
+                  'user_id': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
+                  'identity_data': {
+                    'email': 'fake1@email.com',
+                    'sub': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136'
+                  },
+                  'provider': 'email',
+                  'last_sign_in_at': now,
+                  'created_at': now,
+                  'updated_at': now
+                }
+              ],
+              'created_at': now,
+              'updated_at': now,
+            },
+          ),
+        ),
+      ),
+      201,
+      request: request,
+    );
+  }
+}
+
+/// Client to test out the token refresh retry logic.
+///
+/// This client will fail the first 3 requests and succede on the 4th one.
+class RetryTestHttpClient extends BaseClient {
+  var _requestCount = 0;
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    if (_requestCount < 3) {
+      throw SocketException('Retry #${_requestCount + 1}');
+    }
+    _requestCount++;
     final now = DateTime.now().toIso8601String();
     return StreamedResponse(
       Stream.value(

--- a/test/custom_http_client.dart
+++ b/test/custom_http_client.dart
@@ -65,46 +65,66 @@ class NoEmailConfirmationHttpClient extends BaseClient {
 ///
 /// This client will fail the first 3 requests and succede on the 4th one.
 class RetryTestHttpClient extends BaseClient {
-  var _requestCount = 0;
+  var retryCount = 0;
+
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    if (_requestCount < 3) {
-      throw SocketException('Retry #${_requestCount + 1}');
+    if (retryCount < 3) {
+      retryCount++;
+      throw SocketException('Retry #${retryCount + 1}');
     }
-    _requestCount++;
-    final now = DateTime.now().toIso8601String();
     return StreamedResponse(
       Stream.value(
         utf8.encode(
           jsonEncode(
             {
-              'id': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
-              'aud': 'authenticated',
-              'role': 'authenticated',
-              'email': 'fake1@email.com',
-              'phone': '',
-              'confirmation_sent_at': now,
-              'app_metadata': {
-                'provider': 'email',
-                'providers': ['email']
-              },
-              'user_metadata': {},
-              'identities': [
-                {
-                  'id': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
-                  'user_id': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136',
-                  'identity_data': {
-                    'email': 'fake1@email.com',
-                    'sub': 'ef507d02-ce6a-4b3a-a8a6-6f0e14740136'
-                  },
+              'access_token':
+                  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODAzNDU1MzksInN1YiI6IjE4YmM3YTRlLWMwOTUtNDU3My05M2RjLWUwYmUyOWJhZGE5NyIsImVtYWlsIjoiZmFrZTFAZW1haWwuY29tIiwicGhvbmUiOiIxNjY2MDAwMDAwMDAiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6e30sInJvbGUiOiIiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTY4MDM0MTkzOX1dLCJzZXNzaW9uX2lkIjoiYTg3NjdiOGEtMDcxMS00MGMyLTkzYTEtYTA4MTI3YzFjMzUzIn0.xNV0fCVB8QeeDp44UXlsQ-SdDZm8ZFPKuZVGVZE24Tw',
+              'token_type': 'bearer',
+              'expires_in': 3600,
+              'refresh_token': 'tDoDnvj5MKLuZOQ65KyVfQ',
+              'user': {
+                'id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
+                'aud': '',
+                'role': '',
+                'email': 'fake1@email.com',
+                'email_confirmed_at': '2023-04-01T09:38:59.784028Z',
+                'phone': '166600000000',
+                'phone_confirmed_at': '2023-04-01T09:38:59.784028Z',
+                'confirmed_at': '2023-04-01T09:38:59.784028Z',
+                'last_sign_in_at': '2023-04-01T09:38:59.904492805Z',
+                'app_metadata': {
                   'provider': 'email',
-                  'last_sign_in_at': now,
-                  'created_at': now,
-                  'updated_at': now
-                }
-              ],
-              'created_at': now,
-              'updated_at': now,
+                  'providers': ['email']
+                },
+                'user_metadata': {},
+                'factors': [
+                  {
+                    'id': '1d3aa138-da96-4aea-8217-af07daa6b82d',
+                    'created_at': '2023-04-01T09:38:59.784028Z',
+                    'updated_at': '2023-04-01T09:38:59.784028Z',
+                    'status': 'unverified',
+                    'friendly_name': 'UnverifiedFactor',
+                    'factor_type': 'totp'
+                  }
+                ],
+                'identities': [
+                  {
+                    'id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
+                    'user_id': '18bc7a4e-c095-4573-93dc-e0be29bada97',
+                    'identity_data': {
+                      'email': 'fake1@email.com',
+                      'sub': '18bc7a4e-c095-4573-93dc-e0be29bada97'
+                    },
+                    'provider': 'email',
+                    'last_sign_in_at': '2023-04-01T09:38:59.784028Z',
+                    'created_at': '2023-04-01T09:38:59.784028Z',
+                    'updated_at': '2023-04-01T09:38:59.784028Z'
+                  }
+                ],
+                'created_at': '2023-04-01T09:38:59.784028Z',
+                'updated_at': '2023-04-01T09:38:59.908816Z'
+              }
             },
           ),
         ),


### PR DESCRIPTION
## What kind of change does this PR introduce?

Completers are used in gotrue client to be able to retry token refresh and return the final retry result, but currently the result of `_callRefreshToken` are directly being returned. 

This PR makes `_callRefreshToken` void and makes sure that the result of the completer are returned for those that needs to refresh the session.