### PR TITLE
fix: signedIn event will not fire for passwordRecovery event

### DIFF
--- a/lib/src/gotrue_client.dart
+++ b/lib/src/gotrue_client.dart
@@ -481,9 +481,10 @@ class GoTrueClient {
 
     if (storeSession == true) {
       _saveSession(session);
-      _notifyAllSubscribers(AuthChangeEvent.signedIn);
       if (redirectType == 'recovery') {
         _notifyAllSubscribers(AuthChangeEvent.passwordRecovery);
+      } else {
+        _notifyAllSubscribers(AuthChangeEvent.signedIn);
       }
     }
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -378,7 +378,7 @@ void main() {
       );
     });
 
-    test('Session recovery succedes after retries', () async {
+    test('Session recovery succeeds after retries', () async {
       await client.recoverSession(
           '{"currentSession":{"access_token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODAzNDE3MDUsInN1YiI6IjRkMjU4M2RhLThkZTQtNDlkMy05Y2QxLTM3YTlhNzRmNTViZCIsImVtYWlsIjoiZmFrZTE2ODAzMzgxMDVAZW1haWwuY29tIiwicGhvbmUiOiIiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6eyJIZWxsbyI6IldvcmxkIn0sInJvbGUiOiIiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTY4MDMzODEwNX1dLCJzZXNzaW9uX2lkIjoiYzhiOTg2Y2UtZWJkZC00ZGUxLWI4MjAtZjIyOWYyNjg1OGIwIn0.0x1rFlPKbIU1rZPY1SH_FNSZaXerfkFA1Y-EOlhuzUs","expires_in":3600,"refresh_token":"-yeS4omysFs9tpUYBws9Rg","token_type":"bearer","provider_token":null,"provider_refresh_token":null,"user":{"id":"4d2583da-8de4-49d3-9cd1-37a9a74f55bd","app_metadata":{"provider":"email","providers":["email"]},"user_metadata":{"Hello":"World"},"aud":"","email":"fake1680338105@email.com","phone":"","created_at":"2023-04-01T08:35:05.208586Z","confirmed_at":null,"email_confirmed_at":"2023-04-01T08:35:05.220096086Z","phone_confirmed_at":null,"last_sign_in_at":"2023-04-01T08:35:05.222755878Z","role":"","updated_at":"2023-04-01T08:35:05.226938Z"}},"expiresAt":1680341705}');
       expect(httpClient.retryCount, 3);

--- a/test/custom_http_client.dart
+++ b/test/custom_http_client.dart
@@ -1,7 +1,10 @@
 import 'dart:convert';
 
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:http/http.dart';
 import 'package:universal_io/io.dart';
+
+import 'utils.dart';
 
 class CustomHttpClient extends BaseClient {
   @override
@@ -73,13 +76,19 @@ class RetryTestHttpClient extends BaseClient {
       retryCount++;
       throw SocketException('Retry #${retryCount + 1}');
     }
+    final jwt = JWT(
+      {'exp': (DateTime.now().millisecondsSinceEpoch / 1000).round() + 60},
+      subject: userId1,
+    );
+
     return StreamedResponse(
       Stream.value(
         utf8.encode(
           jsonEncode(
             {
-              'access_token':
-                  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2ODAzNDU1MzksInN1YiI6IjE4YmM3YTRlLWMwOTUtNDU3My05M2RjLWUwYmUyOWJhZGE5NyIsImVtYWlsIjoiZmFrZTFAZW1haWwuY29tIiwicGhvbmUiOiIxNjY2MDAwMDAwMDAiLCJhcHBfbWV0YWRhdGEiOnsicHJvdmlkZXIiOiJlbWFpbCIsInByb3ZpZGVycyI6WyJlbWFpbCJdfSwidXNlcl9tZXRhZGF0YSI6e30sInJvbGUiOiIiLCJhYWwiOiJhYWwxIiwiYW1yIjpbeyJtZXRob2QiOiJwYXNzd29yZCIsInRpbWVzdGFtcCI6MTY4MDM0MTkzOX1dLCJzZXNzaW9uX2lkIjoiYTg3NjdiOGEtMDcxMS00MGMyLTkzYTEtYTA4MTI3YzFjMzUzIn0.xNV0fCVB8QeeDp44UXlsQ-SdDZm8ZFPKuZVGVZE24Tw',
+              'access_token': jwt.sign(
+                SecretKey('37c304f8-51aa-419a-a1af-06154e63707a'),
+              ),
               'token_type': 'bearer',
               'expires_in': 3600,
               'refresh_token': 'tDoDnvj5MKLuZOQ65KyVfQ',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Currently, `signedIn` event fires for every `passwordRecovery` event, which is not so intuitive. This PR prevents from `signedIn` event from firing for a `passwordRecovery` event.

Copied over from this js PR https://github.com/supabase/gotrue-js/pull/629/files